### PR TITLE
Update package.json

### DIFF
--- a/build-process-files/package.json
+++ b/build-process-files/package.json
@@ -7,8 +7,9 @@
   "license": "PRIVATE",
   "private": true,
   "engines": {
-    "node": "12.x"
-  },
+    "node": ">=12.x",
+    "yarn": ">=1.22.x"
+  }
   "devDependencies": {
     "@babel/core": "^7.10.2",
     "@babel/plugin-transform-runtime": "^7.10.1",


### PR DESCRIPTION
PROBLEM: On node versions lower than 12, yarn install hangs due to an incompatible version of node with cypress

node version: 10.19

solution: when upgrading to v12, installation could complete. Let's add this to the package.json file so new devs will know to update to run the project if they don't have >= v12

let's also add the min yarn version which will help to enforce the use of yarn in addition to helping them debug installation issues.